### PR TITLE
🔍 SEO: hreflang alternates & OG locale fixes

### DIFF
--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -1,8 +1,15 @@
 import { SimpleContactForm } from "@/components/SimpleContactForm";
 import { getI18n } from "@/locales/serveur";
+import { setStaticParamsLocale } from "next-international/server";
 import { Metadata } from "next";
 import { seoConfig } from "@/lib/seo-config";
 import { getBreadcrumbSchema } from "@/lib/structured-data";
+
+const ogLocaleMap: Record<string, string> = {
+    fr: 'fr_FR',
+    en: 'en_US',
+    pl: 'pl_PL',
+};
 
 /**
  * Generate metadata for contact page
@@ -14,6 +21,7 @@ export async function generateMetadata({
     params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
     const { locale } = await params;
+    setStaticParamsLocale(locale);
     const t = await getI18n();
 
     const title = t('meta.contact.title');
@@ -27,6 +35,12 @@ export async function generateMetadata({
             canonical: locale === seoConfig.defaultLocale
                 ? `${seoConfig.baseUrl}/contact`
                 : `${seoConfig.baseUrl}/${locale}/contact`,
+            languages: {
+                'fr': `${seoConfig.baseUrl}/contact`,
+                'en': `${seoConfig.baseUrl}/en/contact`,
+                'pl': `${seoConfig.baseUrl}/pl/contact`,
+                'x-default': `${seoConfig.baseUrl}/contact`,
+            },
         },
         openGraph: {
             title,
@@ -35,7 +49,7 @@ export async function generateMetadata({
                 ? `${seoConfig.baseUrl}/contact`
                 : `${seoConfig.baseUrl}/${locale}/contact`,
             siteName: seoConfig.siteName,
-            locale: locale,
+            locale: ogLocaleMap[locale] ?? locale,
             type: 'website',
             images: [
                 {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { Providers } from "./providers";
 import { NavBar } from "@/components/navBar";
 import { seoConfig } from "@/lib/seo-config";
 import { getI18n } from "@/locales/serveur";
+import { setStaticParamsLocale } from "next-international/server";
 import { Toaster } from "@/components/ui/sonner";
 import { SmoothScroll } from "@/components/SmoothScroll";
 import { Analytics as VercelAnalytics } from '@vercel/analytics/next';
@@ -27,12 +28,19 @@ const inter = Inter({
   adjustFontFallback: true,
 });
 
+const ogLocaleMap: Record<string, string> = {
+  fr: 'fr_FR',
+  en: 'en_US',
+  pl: 'pl_PL',
+};
+
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  setStaticParamsLocale(locale);
   const t = await getI18n();
 
   const title = t('meta.home.title');
@@ -78,12 +86,12 @@ export async function generateMetadata({
 
     // Alternates for i18n
     alternates: {
-      canonical: locale === seoConfig.defaultLocale ? seoConfig.baseUrl : `${seoConfig.baseUrl}/${locale}`,
+      canonical: locale === seoConfig.defaultLocale ? `${seoConfig.baseUrl}/` : `${seoConfig.baseUrl}/${locale}`,
       languages: {
+        'fr': `${seoConfig.baseUrl}/`,
         'en': `${seoConfig.baseUrl}/en`,
-        'fr': `${seoConfig.baseUrl}`,
         'pl': `${seoConfig.baseUrl}/pl`,
-        'x-default': `${seoConfig.baseUrl}`,
+        'x-default': `${seoConfig.baseUrl}/`,
       },
     },
 
@@ -107,8 +115,8 @@ export async function generateMetadata({
     // Open Graph
     openGraph: {
       type: 'website',
-      locale: locale,
-      url: locale === seoConfig.defaultLocale ? seoConfig.baseUrl : `${seoConfig.baseUrl}/${locale}`,
+      locale: ogLocaleMap[locale] ?? locale,
+      url: locale === seoConfig.defaultLocale ? `${seoConfig.baseUrl}/` : `${seoConfig.baseUrl}/${locale}`,
       title,
       description,
       siteName: seoConfig.siteName,

--- a/src/app/[locale]/mentions-legales/page.tsx
+++ b/src/app/[locale]/mentions-legales/page.tsx
@@ -1,8 +1,15 @@
 import { getI18n } from '@/locales/serveur';
+import { setStaticParamsLocale } from 'next-international/server';
 import { Metadata } from 'next';
 import { seoConfig } from '@/lib/seo-config';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+
+const ogLocaleMap: Record<string, string> = {
+  fr: 'fr_FR',
+  en: 'en_US',
+  pl: 'pl_PL',
+};
 
 /**
  * Generate metadata for legal notice page
@@ -13,7 +20,8 @@ export async function generateMetadata({
 }: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
-  await params;
+  const { locale } = await params;
+  setStaticParamsLocale(locale);
   const t = await getI18n();
 
   const title = t('meta.legal.title');
@@ -32,12 +40,23 @@ export async function generateMetadata({
       },
     },
     alternates: {
-      canonical: `${seoConfig.baseUrl}/mentions-legales`,
+      canonical: locale === seoConfig.defaultLocale
+        ? `${seoConfig.baseUrl}/mentions-legales`
+        : `${seoConfig.baseUrl}/${locale}/mentions-legales`,
+      languages: {
+        'fr': `${seoConfig.baseUrl}/mentions-legales`,
+        'en': `${seoConfig.baseUrl}/en/mentions-legales`,
+        'pl': `${seoConfig.baseUrl}/pl/mentions-legales`,
+        'x-default': `${seoConfig.baseUrl}/mentions-legales`,
+      },
     },
     openGraph: {
       title,
       description,
-      url: `${seoConfig.baseUrl}/mentions-legales`,
+      url: locale === seoConfig.defaultLocale
+        ? `${seoConfig.baseUrl}/mentions-legales`
+        : `${seoConfig.baseUrl}/${locale}/mentions-legales`,
+      locale: ogLocaleMap[locale] ?? locale,
       images: [
         {
           url: `${seoConfig.baseUrl}${seoConfig.openGraph.image}`,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { getI18n } from "@/locales/serveur";
+import { setStaticParamsLocale } from "next-international/server";
 import Image from "next/image";
 import { knowledge } from "@/lib/data/knowlege.data";
 import { lastwork } from "@/lib/data/lastwork.data";
@@ -17,12 +18,19 @@ import { ContactSection } from "@/components/ContactSection";
 import { FAQSection } from "@/components/FAQSection";
 import { Footer } from "@/components/Footer";
 
+const ogLocaleMap: Record<string, string> = {
+  fr: 'fr_FR',
+  en: 'en_US',
+  pl: 'pl_PL',
+};
+
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
+  setStaticParamsLocale(locale);
   const t = await getI18n();
 
   const title = t('meta.home.title');
@@ -33,14 +41,20 @@ export async function generateMetadata({
     description,
     keywords: t('meta.home.keywords'),
     alternates: {
-      canonical: locale === seoConfig.defaultLocale ? seoConfig.baseUrl : `${seoConfig.baseUrl}/${locale}`,
+      canonical: locale === seoConfig.defaultLocale ? `${seoConfig.baseUrl}/` : `${seoConfig.baseUrl}/${locale}`,
+      languages: {
+        'fr': `${seoConfig.baseUrl}/`,
+        'en': `${seoConfig.baseUrl}/en`,
+        'pl': `${seoConfig.baseUrl}/pl`,
+        'x-default': `${seoConfig.baseUrl}/`,
+      },
     },
     openGraph: {
       title,
       description,
-      url: locale === seoConfig.defaultLocale ? seoConfig.baseUrl : `${seoConfig.baseUrl}/${locale}`,
+      url: locale === seoConfig.defaultLocale ? `${seoConfig.baseUrl}/` : `${seoConfig.baseUrl}/${locale}`,
       siteName: seoConfig.siteName,
-      locale: locale,
+      locale: ogLocaleMap[locale] ?? locale,
       type: 'website',
       images: [
         {

--- a/src/app/[locale]/politique-confidentialite/page.tsx
+++ b/src/app/[locale]/politique-confidentialite/page.tsx
@@ -1,8 +1,15 @@
 import { getI18n, getScopedI18n } from '@/locales/serveur';
+import { setStaticParamsLocale } from 'next-international/server';
 import { Metadata } from 'next';
 import { seoConfig } from '@/lib/seo-config';
 import Link from 'next/link';
 import { ArrowLeft, Shield, Lock, Eye, Database, UserCheck, Clock, FileText, Mail } from 'lucide-react';
+
+const ogLocaleMap: Record<string, string> = {
+  fr: 'fr_FR',
+  en: 'en_US',
+  pl: 'pl_PL',
+};
 
 /**
  * Generate metadata for privacy policy page
@@ -13,7 +20,8 @@ export async function generateMetadata({
 }: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
-  await params;
+  const { locale } = await params;
+  setStaticParamsLocale(locale);
   const t = await getI18n();
 
   const title = t('meta.privacy.title');
@@ -32,12 +40,23 @@ export async function generateMetadata({
       },
     },
     alternates: {
-      canonical: `${seoConfig.baseUrl}/politique-confidentialite`,
+      canonical: locale === seoConfig.defaultLocale
+        ? `${seoConfig.baseUrl}/politique-confidentialite`
+        : `${seoConfig.baseUrl}/${locale}/politique-confidentialite`,
+      languages: {
+        'fr': `${seoConfig.baseUrl}/politique-confidentialite`,
+        'en': `${seoConfig.baseUrl}/en/politique-confidentialite`,
+        'pl': `${seoConfig.baseUrl}/pl/politique-confidentialite`,
+        'x-default': `${seoConfig.baseUrl}/politique-confidentialite`,
+      },
     },
     openGraph: {
       title,
       description,
-      url: `${seoConfig.baseUrl}/politique-confidentialite`,
+      url: locale === seoConfig.defaultLocale
+        ? `${seoConfig.baseUrl}/politique-confidentialite`
+        : `${seoConfig.baseUrl}/${locale}/politique-confidentialite`,
+      locale: ogLocaleMap[locale] ?? locale,
       images: [
         {
           url: `${seoConfig.baseUrl}${seoConfig.openGraph.image}`,

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -2,9 +2,16 @@ import React from 'react'
 import { lastwork } from '@/lib/data/lastwork.data'
 import { ProjectCard } from '@/components/ProjectCard'
 import { getI18n } from '@/locales/serveur'
+import { setStaticParamsLocale } from 'next-international/server'
 import { Metadata } from 'next'
 import { seoConfig } from '@/lib/seo-config'
 import { getProjectsListSchema, getBreadcrumbSchema } from '@/lib/structured-data'
+
+const ogLocaleMap: Record<string, string> = {
+    fr: 'fr_FR',
+    en: 'en_US',
+    pl: 'pl_PL',
+};
 
 export async function generateMetadata({
     params,
@@ -12,6 +19,7 @@ export async function generateMetadata({
     params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
     const { locale } = await params;
+    setStaticParamsLocale(locale);
     const t = await getI18n();
 
     const title = t('meta.projects.title');
@@ -25,6 +33,12 @@ export async function generateMetadata({
             canonical: locale === seoConfig.defaultLocale
                 ? `${seoConfig.baseUrl}/projects`
                 : `${seoConfig.baseUrl}/${locale}/projects`,
+            languages: {
+                'fr': `${seoConfig.baseUrl}/projects`,
+                'en': `${seoConfig.baseUrl}/en/projects`,
+                'pl': `${seoConfig.baseUrl}/pl/projects`,
+                'x-default': `${seoConfig.baseUrl}/projects`,
+            },
         },
         openGraph: {
             title,
@@ -33,7 +47,7 @@ export async function generateMetadata({
                 ? `${seoConfig.baseUrl}/projects`
                 : `${seoConfig.baseUrl}/${locale}/projects`,
             siteName: seoConfig.siteName,
-            locale: locale,
+            locale: ogLocaleMap[locale] ?? locale,
             type: 'website',
             images: [
                 {


### PR DESCRIPTION
## Summary
- Add `ogLocaleMap` for proper Open Graph locale format (`fr_FR`, `en_US`, `pl_PL`)
- Add `alternates.languages` (hreflang) to all pages for better international SEO
- Call `setStaticParamsLocale` in all `generateMetadata` functions
- Fix canonical URLs trailing slash consistency

## Files changed
- `src/app/[locale]/layout.tsx`
- `src/app/[locale]/page.tsx`
- `src/app/[locale]/contact/page.tsx`
- `src/app/[locale]/projects/page.tsx`
- `src/app/[locale]/mentions-legales/page.tsx`
- `src/app/[locale]/politique-confidentialite/page.tsx`

## Test plan
- [ ] Verify hreflang tags render correctly in page source
- [ ] Check OG locale format in social media debuggers
- [ ] Verify canonical URLs are correct for all locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)