### PR TITLE
♿ A11y: skip-to-content, form labels & heading hierarchy

### DIFF
--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -83,7 +83,8 @@ export default async function ContactPage({
                 suppressHydrationWarning
             />
 
-            <main className="min-h-screen bg-black">
+            <main id="main-content" className="min-h-screen bg-black">
+                <h1 className="sr-only">Contact Patrick Bartosik</h1>
                 <SimpleContactForm />
             </main>
         </>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -161,6 +161,12 @@ export default async function RootLayout({
         className={`${anton.variable} ${inter.variable} antialiased dark:bg-black bg-black`}
         suppressHydrationWarning
       >
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-white focus:text-black focus:rounded-lg focus:text-sm focus:font-medium"
+        >
+          Skip to main content
+        </a>
         <Providers locale={locale}>
           <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID || ''} />
           <SmoothScroll>

--- a/src/app/[locale]/mentions-legales/page.tsx
+++ b/src/app/[locale]/mentions-legales/page.tsx
@@ -64,7 +64,7 @@ export default async function LegalNoticePage({
   });
 
   return (
-    <main className="relative min-h-screen w-full px-8 md:px-16 lg:px-24 py-32">
+    <main id="main-content" className="relative min-h-screen w-full px-8 md:px-16 lg:px-24 py-32">
       {/* Back button */}
       <Link
         href="/"

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -146,7 +146,7 @@ export default async function Home({
         suppressHydrationWarning
       />
 
-      <main className="relative w-full">
+      <main id="main-content" className="relative w-full">
         {/* Hero Section - Split Text Animation */}
         <HeroSection
           title={t('hero.title')}

--- a/src/app/[locale]/politique-confidentialite/page.tsx
+++ b/src/app/[locale]/politique-confidentialite/page.tsx
@@ -76,7 +76,7 @@ export default async function PrivacyPolicyPage({
   ] as const;
 
   return (
-    <main className="relative min-h-screen w-full px-8 md:px-16 lg:px-24 py-32">
+    <main id="main-content" className="relative min-h-screen w-full px-8 md:px-16 lg:px-24 py-32">
       {/* Back button */}
       <Link
         href="/"

--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -87,7 +87,7 @@ export default async function ProjectsPage({
                 suppressHydrationWarning
             />
 
-            <main className="relative min-h-screen w-full pt-20 pb-16">
+            <main id="main-content" className="relative min-h-screen w-full pt-20 pb-16">
                 {/* Header Section */}
                 <section className="px-8 md:px-16 lg:px-24 py-16">
                     <h1 className="text-6xl md:text-7xl lg:text-8xl xl:text-[140px] leading-tight uppercase font-bold">

--- a/src/components/SimpleContactForm.tsx
+++ b/src/components/SimpleContactForm.tsx
@@ -178,9 +178,9 @@ export const SimpleContactForm = () => {
                     {currentStep === 1 && (
                         <div className="space-y-8">
                             <div className="space-y-4">
-                                <h1 className="text-4xl md:text-5xl font-bold text-white leading-tight">
+                                <h2 className="text-4xl md:text-5xl font-bold text-white leading-tight">
                                     Bonjour ! 👋
-                                </h1>
+                                </h2>
                                 <p className="text-xl text-white/60">
                                     Commençons par faire connaissance
                                 </p>
@@ -189,10 +189,11 @@ export const SimpleContactForm = () => {
                             <div className="space-y-6">
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                     <div>
-                                        <label className="block text-white/80 text-sm font-medium mb-3">
+                                        <label htmlFor="firstName" className="block text-white/80 text-sm font-medium mb-3">
                                             Prénom *
                                         </label>
                                         <Input
+                                            id="firstName"
                                             {...register("firstName")}
                                             placeholder="John"
                                             className="h-14 bg-white/5 border-white/10 text-white text-lg placeholder:text-white/30 focus:border-orange-500"
@@ -206,10 +207,11 @@ export const SimpleContactForm = () => {
                                     </div>
 
                                     <div>
-                                        <label className="block text-white/80 text-sm font-medium mb-3">
+                                        <label htmlFor="lastName" className="block text-white/80 text-sm font-medium mb-3">
                                             Nom *
                                         </label>
                                         <Input
+                                            id="lastName"
                                             {...register("lastName")}
                                             placeholder="Doe"
                                             className="h-14 bg-white/5 border-white/10 text-white text-lg placeholder:text-white/30 focus:border-orange-500"
@@ -223,10 +225,11 @@ export const SimpleContactForm = () => {
                                 </div>
 
                                 <div>
-                                    <label className="block text-white/80 text-sm font-medium mb-3">
+                                    <label htmlFor="email" className="block text-white/80 text-sm font-medium mb-3">
                                         Email *
                                     </label>
                                     <Input
+                                        id="email"
                                         {...register("email")}
                                         type="email"
                                         placeholder="john@example.com"
@@ -240,10 +243,11 @@ export const SimpleContactForm = () => {
                                 </div>
 
                                 <div>
-                                    <label className="block text-white/80 text-sm font-medium mb-3">
+                                    <label htmlFor="phone" className="block text-white/80 text-sm font-medium mb-3">
                                         Téléphone (optionnel)
                                     </label>
                                     <PhoneInput
+                                        id="phone"
                                         value={watch("phone")}
                                         onChange={(value) => setValue("phone", value)}
                                         placeholder="+33 6 12 34 56 78"
@@ -268,10 +272,11 @@ export const SimpleContactForm = () => {
 
                             <div className="space-y-6">
                                 <div>
-                                    <label className="block text-white/80 text-sm font-medium mb-3">
+                                    <label htmlFor="companyName" className="block text-white/80 text-sm font-medium mb-3">
                                         Nom de la marque *
                                     </label>
                                     <Input
+                                        id="companyName"
                                         {...register("companyName")}
                                         placeholder="Acme Inc."
                                         className="h-14 bg-white/5 border-white/10 text-white text-lg placeholder:text-white/30 focus:border-orange-500"
@@ -285,10 +290,11 @@ export const SimpleContactForm = () => {
                                 </div>
 
                                 <div>
-                                    <label className="block text-white/80 text-sm font-medium mb-3">
+                                    <label htmlFor="companyWebsite" className="block text-white/80 text-sm font-medium mb-3">
                                         Site web (optionnel)
                                     </label>
                                     <Input
+                                        id="companyWebsite"
                                         {...register("companyWebsite")}
                                         type="url"
                                         placeholder="https://acme.com"
@@ -342,10 +348,11 @@ export const SimpleContactForm = () => {
                                 {/* CMS e-commerce si sélectionné */}
                                 {serviceType === "ecommerce" && (
                                     <div>
-                                        <label className="block text-white/80 text-sm font-medium mb-3">
+                                        <label htmlFor="ecommerceCms" className="block text-white/80 text-sm font-medium mb-3">
                                             CMS utilisé *
                                         </label>
                                         <select
+                                            id="ecommerceCms"
                                             {...register("ecommerceCms")}
                                             className="w-full h-14 bg-white/5 border border-white/10 rounded-xl text-white text-lg px-4 focus:border-orange-500"
                                         >
@@ -480,10 +487,11 @@ export const SimpleContactForm = () => {
                                 )}
 
                                 <div>
-                                    <label className="block text-white/80 text-sm font-medium mb-3">
+                                    <label htmlFor="message" className="block text-white/80 text-sm font-medium mb-3">
                                         Message (optionnel)
                                     </label>
                                     <Textarea
+                                        id="message"
                                         {...register("message")}
                                         placeholder="Parlez-moi de votre projet, vos objectifs, vos contraintes..."
                                         rows={4}

--- a/src/components/form/PhoneInput.tsx
+++ b/src/components/form/PhoneInput.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { parsePhoneNumber, isValidPhoneNumber, CountryCode } from "libphonenumber-js";
 
 interface PhoneInputProps {
+    id?: string;
     value?: string;
     onChange: (value: string) => void;
     placeholder?: string;
@@ -25,7 +26,7 @@ const POPULAR_COUNTRIES: { code: CountryCode; name: string; dial: string; flag: 
     { code: "CA", name: "Canada", dial: "+1", flag: "🇨🇦" },
 ];
 
-export function PhoneInput({ value, onChange, placeholder, error, disabled }: PhoneInputProps) {
+export function PhoneInput({ id, value, onChange, placeholder, error, disabled }: PhoneInputProps) {
     const [selectedCountry, setSelectedCountry] = useState<CountryCode>("FR");
     const [showDropdown, setShowDropdown] = useState(false);
 
@@ -156,6 +157,7 @@ export function PhoneInput({ value, onChange, placeholder, error, disabled }: Ph
                 {/* Phone Input */}
                 <div className="flex-1 relative">
                     <Input
+                        id={id}
                         type="tel"
                         value={displayValue}
                         onChange={(e) => handlePhoneChange(e.target.value)}


### PR DESCRIPTION
## Summary
- Add skip-to-content link in root layout for keyboard navigation
- Add `id="main-content"` on all page `<main>` elements
- Associate all form labels with `htmlFor`/`id` attributes in SimpleContactForm
- Fix heading hierarchy (`h1` → `h2` in SimpleContactForm, sr-only `h1` on contact page)

## Files changed
- `src/app/[locale]/layout.tsx`
- `src/app/[locale]/page.tsx`, `contact/page.tsx`, `projects/page.tsx`, `mentions-legales/page.tsx`, `politique-confidentialite/page.tsx`
- `src/components/SimpleContactForm.tsx`
- `src/components/form/PhoneInput.tsx`

## Test plan
- [ ] Tab through the page — skip-to-content link should appear on focus
- [ ] Verify form labels are properly associated (click label → focus input)
- [ ] Run axe or Lighthouse accessibility audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)