### PR TITLE
♻️ GSAP: centralize imports & remove unused plugins

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 
 interface AboutSectionProps {
     label: string;

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Image from "next/image";
 import SplitType from "split-type";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,10 +19,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 // Schéma de validation Zod
 const contactFormSchema = z.object({

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
+import { gsap } from "@/lib/gsap-config";
 
 export const CustomCursor = () => {
     const cursorRef = useRef<HTMLDivElement>(null);

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import {
     Accordion,
     AccordionContent,
@@ -10,10 +9,6 @@ import {
     AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Github, Instagram, Linkedin, Mail } from "lucide-react";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface FAQ {
     question: string;

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,16 +1,11 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Image from "next/image";
 import SplitType from "split-type";
 import Link from "next/link";
 import heroImage from "../../public/images/hero.webp";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface HeroSectionProps {
     title: string;

--- a/src/components/KnowledgeSection.tsx
+++ b/src/components/KnowledgeSection.tsx
@@ -1,13 +1,8 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Image from "next/image";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface KnowledgeItem {
     title: string;

--- a/src/components/LatestProjectsSection.tsx
+++ b/src/components/LatestProjectsSection.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Image from "next/image";
 import { ArrowUpRight } from "lucide-react";
 import { Project } from "@/lib/data/lastwork.data";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface LatestProjectsSectionProps {
     title: string;

--- a/src/components/LatestWorkTimeline.tsx
+++ b/src/components/LatestWorkTimeline.tsx
@@ -3,12 +3,9 @@
 import { useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { gsap } from 'gsap'
-import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { gsap, ScrollTrigger } from '@/lib/gsap-config'
 import { lastwork } from '@/lib/data/lastwork.data'
 import { ArrowUpRight } from 'lucide-react'
-
-gsap.registerPlugin(ScrollTrigger)
 
 export function LatestWorkTimeline() {
     const [activeIndex, setActiveIndex] = useState(0)

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { gsap } from "gsap";
-import { SplitText } from "gsap/SplitText";
-import { CustomEase } from "gsap/CustomEase";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(SplitText, CustomEase);
-}
+import { gsap, SplitText, CustomEase } from "@/lib/gsap-config";
 
 export const PageLoader = () => {
     const loaderRef = useRef<HTMLDivElement>(null);

--- a/src/components/ProjectTestimonial.tsx
+++ b/src/components/ProjectTestimonial.tsx
@@ -1,13 +1,8 @@
 "use client"
 
 import { useEffect, useRef } from "react"
-import { gsap } from "gsap"
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger"
+import { gsap, ScrollTrigger } from "@/lib/gsap-config"
 import type { ProjectTestimonial } from "@/lib/data/testimonials.data"
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger)
-}
 
 interface ProjectTestimonialProps {
     testimonial: ProjectTestimonial

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Link from "next/link";
 import type { Service } from "@/lib/data/services.data";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface ServicesSectionProps {
     title: string;

--- a/src/components/SimpleContactForm.tsx
+++ b/src/components/SimpleContactForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { gsap } from "gsap";
+import { gsap } from "@/lib/gsap-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -2,12 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import Lenis from "lenis";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 
 interface SmoothScrollProps {
     children: React.ReactNode;

--- a/src/components/StatsSection.tsx
+++ b/src/components/StatsSection.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useMemo } from "react";
-import { gsap } from "gsap";
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger";
+import { gsap, ScrollTrigger } from "@/lib/gsap-config";
 import Image from "next/image";
 import Autoplay from "embla-carousel-autoplay";
 import {
@@ -12,10 +11,6 @@ import {
     CarouselNext,
     CarouselPrevious,
 } from "@/components/ui/carousel";
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger);
-}
 
 interface Testimonial {
     name: string;

--- a/src/components/TestimonialsGrid.tsx
+++ b/src/components/TestimonialsGrid.tsx
@@ -1,13 +1,8 @@
 "use client"
 
 import { useEffect, useRef } from "react"
-import { gsap } from "gsap"
-import { ScrollTrigger } from "gsap/dist/ScrollTrigger"
+import { gsap, ScrollTrigger } from "@/lib/gsap-config"
 import type { ProjectTestimonial } from "@/lib/data/testimonials.data"
-
-if (typeof window !== "undefined") {
-    gsap.registerPlugin(ScrollTrigger)
-}
 
 interface TestimonialsGridProps {
     testimonials: ProjectTestimonial[]

--- a/src/lib/gsap-config.ts
+++ b/src/lib/gsap-config.ts
@@ -1,60 +1,11 @@
 import { gsap } from "gsap";
 import { useGSAP } from "@gsap/react";
-
 import { CustomEase } from "gsap/CustomEase";
-import { CustomBounce } from "gsap/CustomBounce";
-import { CustomWiggle } from "gsap/CustomWiggle";
-import { RoughEase, ExpoScaleEase, SlowMo } from "gsap/EasePack";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+import { SplitText } from "gsap/SplitText";
 
-import { Draggable } from "gsap/all";
-import { DrawSVGPlugin } from "gsap/all";
-import { EaselPlugin } from "gsap/all";
-import { Flip } from "gsap/all";
-import { GSDevTools } from "gsap/all";
-import { InertiaPlugin } from "gsap/all";
-import { MotionPathHelper } from "gsap/all";
-import { MotionPathPlugin } from "gsap/all";
-import { MorphSVGPlugin } from "gsap/all";
-import { Observer } from "gsap/all";
-import { Physics2DPlugin } from "gsap/all";
-import { PhysicsPropsPlugin } from "gsap/all";
-import { PixiPlugin } from "gsap/all";
-import { ScrambleTextPlugin } from "gsap/all";
-import { ScrollTrigger } from "gsap/all";
-import { ScrollSmoother } from "gsap/all";
-import { ScrollToPlugin } from "gsap/all";
-import { SplitText } from "gsap/all";
-import { TextPlugin } from "gsap/all";
-
-// Enregistrer tous les plugins GSAP premium
-gsap.registerPlugin(
-    useGSAP,
-    Draggable,
-    DrawSVGPlugin,
-    EaselPlugin,
-    Flip,
-    GSDevTools,
-    InertiaPlugin,
-    MotionPathHelper,
-    MotionPathPlugin,
-    MorphSVGPlugin,
-    Observer,
-    Physics2DPlugin,
-    PhysicsPropsPlugin,
-    PixiPlugin,
-    ScrambleTextPlugin,
-    ScrollTrigger,
-    ScrollSmoother,
-    ScrollToPlugin,
-    SplitText,
-    TextPlugin,
-    RoughEase,
-    ExpoScaleEase,
-    SlowMo,
-    CustomEase,
-    CustomBounce,
-    CustomWiggle
-);
+// Register only the plugins that are actually used in the codebase
+gsap.registerPlugin(useGSAP, ScrollTrigger, SplitText, CustomEase);
 
 if (typeof window !== "undefined") {
     // Configuration globale optimisée pour ScrollTrigger
@@ -79,32 +30,7 @@ if (typeof window !== "undefined") {
     });
 }
 
-// Exporter tous les plugins utiles
-export {
-    gsap,
-    useGSAP,
-    ScrollTrigger,
-    ScrollSmoother,
-    SplitText,
-    Flip,
-    Draggable,
-    Observer,
-    ScrollToPlugin,
-    DrawSVGPlugin,
-    MorphSVGPlugin,
-    MotionPathPlugin,
-    TextPlugin,
-    ScrambleTextPlugin,
-    CustomEase,
-    CustomBounce,
-    CustomWiggle,
-    RoughEase,
-    ExpoScaleEase,
-    SlowMo,
-    GSDevTools,
-    InertiaPlugin,
-};
+export { gsap, useGSAP, ScrollTrigger, SplitText, CustomEase };
 
-// Export par défaut pour faciliter l'import
 export default gsap;
 


### PR DESCRIPTION
## Summary
- Replace all direct `gsap`/`gsap/dist/*` imports with `@/lib/gsap-config`
- Remove duplicate `gsap.registerPlugin()` calls from 15 components
- Trim `gsap-config.ts` to only register and export actually used plugins (ScrollTrigger, SplitText, CustomEase)
- **Reduces bundle size** by not registering 20+ unused GSAP plugins

## Files changed
- `src/lib/gsap-config.ts`
- 15 component files (AboutSection, ContactSection, HeroSection, etc.)

## Test plan
- [ ] Verify all GSAP animations still work (scroll triggers, split text, etc.)
- [ ] Check bundle size reduction
- [ ] Test on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)