### PR TITLE
♿ Reduced motion: respect prefers-reduced-motion

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -450,3 +450,15 @@
     will-change: transform;
   }
 }
+
+/* Accessibility: Respect user preference for reduced motion (WCAG 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -24,6 +24,18 @@ export const AboutSection = ({ label, text }: AboutSectionProps) => {
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) {
+            // Make words visible immediately when animations are disabled
+            wordsRef.current.forEach((word) => {
+                if (word) {
+                    word.style.opacity = '1';
+                    word.style.filter = 'none';
+                }
+            });
+            return;
+        }
+
         const ctx = gsap.context(() => {
             // Parallax subtil sur le label
             if (labelRef.current) {

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -118,6 +118,9 @@ export const ContactSection = ({ translations }: ContactSectionProps) => {
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         const ctx = gsap.context(() => {
             // Animation du heading avec split text
             if (headingRef.current) {

--- a/src/components/FAQSection.tsx
+++ b/src/components/FAQSection.tsx
@@ -41,6 +41,9 @@ export const FAQSection = ({ title, faqs, socialTitle, socialLinks }: FAQSection
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         const ctx = gsap.context(() => {
             // Animation du titre avec scale effect
             if (titleRef.current) {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -39,6 +39,9 @@ export const HeroSection = ({
     useEffect(() => {
         if (!sectionRef.current || !nameRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         // Détection mobile pour optimiser les animations
         const isMobile = window.matchMedia('(max-width: 767px)').matches;
 

--- a/src/components/KnowledgeSection.tsx
+++ b/src/components/KnowledgeSection.tsx
@@ -35,6 +35,9 @@ export const KnowledgeSection = ({
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         const ctx = gsap.context(() => {
             // Animation du titre avec parallax
             if (titleRef.current) {

--- a/src/components/LatestProjectsSection.tsx
+++ b/src/components/LatestProjectsSection.tsx
@@ -202,6 +202,9 @@ export const LatestProjectsSection = ({
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         const ctx = gsap.context(() => {
             // Parallax sur le titre
             if (titleRef.current) {

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -25,6 +25,9 @@ export const ServicesSection = ({ title, services, locale, ctaText }: ServicesSe
     useEffect(() => {
         if (!sectionRef.current) return;
 
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         const ctx = gsap.context(() => {
             // Animation du titre avec parallax
             if (titleRef.current) {

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -17,6 +17,9 @@ export const SmoothScroll = ({ children }: SmoothScrollProps) => {
     const lenisRef = useRef<Lenis | null>(null);
 
     useEffect(() => {
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (prefersReducedMotion) return;
+
         // Détection mobile pour ajuster les paramètres
         const isMobile = window.matchMedia('(max-width: 767px)').matches;
 


### PR DESCRIPTION
## Summary
- Add CSS `prefers-reduced-motion` media query to disable all CSS animations/transitions
- Add motion preference check in all GSAP-animated components (early return if reduced motion)
- Skip Lenis smooth scroll initialization when reduced motion is preferred
- Ensures WCAG 2.3.3 compliance

## Files changed
- `src/app/[locale]/globals.css`
- 8 component files (AboutSection, ContactSection, HeroSection, SmoothScroll, etc.)

## Test plan
- [ ] Enable "Reduce motion" in OS settings → verify no animations play
- [ ] Disable "Reduce motion" → verify all animations work normally
- [ ] Check that content is still visible when animations are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)