### PR TITLE
🤖 Robots/Proxy: allow AI bots & exclude llms.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -36,10 +36,11 @@ export default function robots(): MetadataRoute.Robots {
                     '/*.js.map$',
                 ],
             },
-            // Règles spécifiques pour les bots AI agressifs
+            // Règles spécifiques pour les bots AI — autoriser les pages publiques
             {
-                userAgent: ['GPTBot', 'ChatGPT-User', 'CCBot', 'anthropic-ai', 'Google-Extended'],
-                disallow: ['/'],
+                userAgent: ['GPTBot', 'ChatGPT-User', 'anthropic-ai', 'PerplexityBot', 'Google-Extended', 'CCBot'],
+                allow: ['/', '/en/', '/pl/', '/projects', '/contact'],
+                disallow: ['/api/'],
             },
         ],
         sitemap: `${seoConfig.baseUrl}/sitemap.xml`,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,5 +12,5 @@ export default function proxy(request: NextRequest) {
 }
 
 export const config = {
-    matcher: ["/((?!api|_next/static|_next/image|favicon.ico|images|icons|svg|og|sitemap.xml|robots.txt|cv.pdf|CV.pdf|not-found).*)"],
+    matcher: ["/((?!api|_next/static|_next/image|favicon.ico|images|icons|svg|og|sitemap.xml|robots.txt|llms.txt|llms-full.txt|cv.pdf|CV.pdf|not-found).*)"],
 };


### PR DESCRIPTION
## Summary
- Update `robots.ts` to allow AI bots (GPTBot, PerplexityBot, etc.) on public pages
- Only block `/api/` for AI bots instead of blocking everything
- Add `llms.txt` and `llms-full.txt` to proxy matcher exclusions so they're served directly

## Files changed
- `src/app/robots.ts`
- `src/proxy.ts`

## Test plan
- [ ] Verify robots.txt output allows AI bots on public pages
- [ ] Verify `/llms.txt` is accessible without redirect
- [ ] Check that `/api/*` routes are still blocked for AI bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)