### PR TITLE
Sprint 2: SEO & Structured Data Fixes

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -10,58 +10,47 @@ import { seoConfig } from '@/lib/seo-config';
 export default function sitemap(): MetadataRoute.Sitemap {
     const { baseUrl, locales, defaultLocale } = seoConfig;
 
-    // Date de dernière modification (à ajuster selon vos besoins)
-    const currentDate = new Date();
-    const lastModifiedHome = new Date('2025-11-06'); // Date de dernière mise à jour majeure
-    const lastModifiedProjects = new Date('2025-11-06');
-    const lastModifiedContact = new Date('2025-11-01');
-    const lastModifiedLegal = new Date('2025-01-01');
+    // Date de dernière modification dynamique (reflète la date du dernier déploiement)
+    const lastModified = new Date();
 
     // Pages statiques principales avec leurs configurations SEO
     const staticPages: Array<{
         path: string;
         priority: number;
         changeFrequency: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
-        lastModified: Date;
     }> = [
             {
                 path: '',
                 priority: 1.0,
                 changeFrequency: 'weekly',
-                lastModified: lastModifiedHome,
             },
             {
                 path: '/projects',
                 priority: 0.9,
                 changeFrequency: 'weekly',
-                lastModified: lastModifiedProjects,
             },
             {
                 path: '/contact',
                 priority: 0.8,
                 changeFrequency: 'monthly',
-                lastModified: lastModifiedContact,
             },
         ];
 
-    // Pages légales (FR uniquement)
+    // Pages légales (FR uniquement — pas d'alternates en/pl)
     const legalPagesFr: Array<{
         path: string;
         priority: number;
         changeFrequency: 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
-        lastModified: Date;
     }> = [
             {
                 path: '/mentions-legales',
                 priority: 0.3,
                 changeFrequency: 'yearly',
-                lastModified: lastModifiedLegal,
             },
             {
                 path: '/politique-confidentialite',
                 priority: 0.3,
                 changeFrequency: 'yearly',
-                lastModified: lastModifiedLegal,
             },
         ];
 
@@ -86,7 +75,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
             urls.push({
                 url,
-                lastModified: page.lastModified,
+                lastModified,
                 changeFrequency: page.changeFrequency,
                 priority: page.priority,
                 alternates: {
@@ -96,13 +85,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
         });
     });
 
-    // Pages légales (FR uniquement)
+    // Pages légales (FR uniquement avec hreflang fr + x-default)
     legalPagesFr.forEach((page) => {
+        const frUrl = `${baseUrl}${page.path}`;
         urls.push({
-            url: `${baseUrl}${page.path}`,
-            lastModified: page.lastModified,
+            url: frUrl,
+            lastModified,
             changeFrequency: page.changeFrequency,
             priority: page.priority,
+            alternates: {
+                languages: {
+                    fr: frUrl,
+                    'x-default': frUrl,
+                },
+            },
         });
     });
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -8,14 +8,29 @@ import { Project } from './data/lastwork.data';
  * @returns Schema.org Person object
  */
 export function getPersonSchema(locale: string) {
+    const jobTitles: Record<string, string> = {
+        en: 'Full Stack Developer',
+        fr: 'Developpeur Full Stack',
+        pl: 'Full Stack Developer',
+    };
+
+    const descriptions: Record<string, string> = {
+        en: 'Freelance Full Stack Developer specializing in React, Next.js, TypeScript and Node.js applications',
+        fr: 'Developpeur Full Stack freelance specialise en React, Next.js, TypeScript et Node.js',
+        pl: 'Freelance Full Stack Developer specjalizujacy sie w React, Next.js, TypeScript i Node.js',
+    };
+
     return {
         '@context': 'https://schema.org',
         '@type': 'Person',
         name: seoConfig.author.name,
         url: seoConfig.author.url,
-        jobTitle: seoConfig.author.jobTitle,
+        jobTitle: jobTitles[locale] || jobTitles.en,
+        description: descriptions[locale] || descriptions.en,
         email: seoConfig.author.email,
         image: `${seoConfig.baseUrl}/images/hero.webp`,
+        inLanguage: locale,
+        knowsLanguage: ['fr', 'en', 'pl'],
         sameAs: [
             seoConfig.social.github,
             seoConfig.social.linkedin,
@@ -110,22 +125,20 @@ export function getBreadcrumbSchema(
     };
 }
 
-// Organization Schema
+// Person Schema (replaces Organization — this is a freelancer portfolio, not a company)
 export function getOrganizationSchema() {
     return {
         '@context': 'https://schema.org',
-        '@type': 'Organization',
-        name: seoConfig.siteName,
+        '@type': 'Person',
+        name: seoConfig.author.name,
         url: seoConfig.baseUrl,
-        logo: `${seoConfig.baseUrl}/images/logo.png`,
-        contactPoint: {
-            '@type': 'ContactPoint',
-            email: seoConfig.author.email,
-            contactType: 'Customer Service',
-        },
+        image: `${seoConfig.baseUrl}/images/hero.webp`,
+        email: seoConfig.author.email,
+        jobTitle: seoConfig.author.jobTitle,
         sameAs: [
             seoConfig.social.github,
             seoConfig.social.linkedin,
+            seoConfig.social.instagram,
         ],
     };
 }
@@ -156,7 +169,7 @@ export function getProfessionalServiceSchema(locale: string) {
                 name: 'France',
             },
             {
-                '@type': 'Country',
+                '@type': 'Continent',
                 name: 'Europe',
             },
         ],

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -356,7 +356,7 @@ export default {
     'meta': {
         'home': {
             'title': 'Patrick Bartosik | Next.js Expert & Freelance Full Stack Developer',
-            'description': 'Looking to hire a Next.js Expert? Freelance Full Stack Developer expert in React, Next.js, TypeScript & Node.js. I help startups and businesses build high-performance web apps with Next.js. Open source React framework for server-side rendering. SaaS & Shopify Plus specialist. Based in France, working worldwide.',
+            'description': 'Freelance Full Stack Developer expert in Next.js, React, TypeScript & Node.js. I build high-performance web apps, SaaS & Shopify Plus solutions.',
             'keywords': 'hire full stack developer, freelance react developer, next.js developer for hire, full stack developer europe, react developer freelance, hire next.js developer, typescript expert, freelance full stack developer, saas developer, ecommerce developer, shopify plus developer, web developer for hire, react typescript developer, nodejs developer freelance, hire web developer france',
         },
         'projects': {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -356,7 +356,7 @@ export default {
     'meta': {
         'home': {
             'title': 'Patrick Bartosik | Expert Next.js & Développeur Full Stack Freelance Paris',
-            'description': 'Développeur Full Stack freelance expert Next.js à Paris. Spécialiste React, Next.js, TypeScript & Node.js. J\'aide startups et entreprises à créer des applications web performantes avec Next.js. Framework React open source pour le rendu côté serveur. SaaS, e-commerce Shopify Plus. +4 ans d\'expérience.',
+            'description': 'Développeur Full Stack freelance expert Next.js à Paris. Spécialiste React, TypeScript & Node.js. Applications web, SaaS et e-commerce Shopify Plus.',
             'keywords': 'développeur next.js paris, expert next.js freelance, développeur full stack paris, développeur freelance france, freelance react paris, développeur next.js freelance, expert react next.js, frameworks react, next.js supports, server side, rendu côté serveur, créer des applications web, open source, développeur backend nodejs, développeur shopify plus, expert typescript, freelance full stack, développeur saas, développeur e-commerce, développeur react typescript, développeur web freelance paris, freelance react developer france, développeur angular, développeur nestjs, développeur api rest, développeur graphql, hire react developer france',
         },
         'projects': {

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -356,7 +356,7 @@ export default {
     'meta': {
         'home': {
             'title': 'Patrick Bartosik | Ekspert Next.js & Full Stack Developer Freelance',
-            'description': 'Szukasz Eksperta Next.js? Full Stack Developer ekspert React, Next.js, TypeScript & Node.js. Pomagam startupom i firmom tworzyć wydajne aplikacje webowe z Next.js. Otwartoźródłowy framework React do renderowania po stronie serwera. Specjalista SaaS i Shopify Plus. +4 lata doświadczenia.',
+            'description': 'Freelance Full Stack Developer i ekspert Next.js, React, TypeScript & Node.js. Wydajne aplikacje webowe, SaaS i rozwiązania Shopify Plus.',
             'keywords': 'zatrudnij full stack developer, programista react freelance, programista next.js, full stack developer europa, freelance developer, ekspert react next.js, programista typescript, programista saas, programista ecommerce, programista shopify plus, programista web, programista react typescript, programista nodejs freelance',
         },
         'projects': {


### PR DESCRIPTION
## Summary
- **[MAJ-05/ARCH-17]** Dynamic sitemap dates (`new Date()` instead of hardcoded)
- **[ARCH-31]** Structured data `getPersonSchema()` now uses locale param for `inLanguage`, `jobTitle`, `description`
- **[ARCH-32/MIN-07]** Legal pages (mentions-legales, politique-confidentialite) FR-only hreflang in sitemap
- **[MIN-02]** Schema `@type: Organization` → `@type: Person` (freelancer portfolio)
- **[MIN-10]** `areaServed` Europe: `@type: Country` → `@type: Continent`
- **[MIN-06]** Meta descriptions shortened to ~150 chars (was ~260)

## Test plan
- [ ] `bun run build` passes
- [ ] Validate sitemap.xml has dynamic dates
- [ ] Validate legal pages have only FR hreflang
- [ ] Test structured data with Google Rich Results Test
- [ ] Verify meta descriptions render correctly in all 3 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)