### PR TITLE
Sprint 2: i18n Hardcoded Texts Localization

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -163,6 +163,7 @@ export default async function Home({
           ctaSecondary={t('hero.cta_secondary')}
           ctaTertiary={t('hero.download_cv')}
           altText={t('alt.hero')}
+          scrollText={t('hero.scroll')}
         />
 
         {/* About Section - Animation GSAP au scroll */}
@@ -246,7 +247,7 @@ export default async function Home({
             contactCompany: t('contact.contactCompany'),
             contactName: t('contact.contactName'),
             contactCta: t('contact.contactCta'),
-            copyright: t('contact.copyright'),
+            copyright: t('contact.copyright', { year: new Date().getFullYear().toString() }),
           }}
         />
 
@@ -258,7 +259,7 @@ export default async function Home({
           socialLinks={{
             linkedin: seoConfig.social.linkedin,
             github: seoConfig.social.github,
-            instagram: 'https://www.instagram.com/empereur.patrick/',
+            instagram: seoConfig.social.instagram,
             email: seoConfig.author.email,
           }}
         />
@@ -278,12 +279,13 @@ export default async function Home({
           legal: t('footer.legal'),
           legalTerms: t('footer.legalTerms'),
           legalPrivacy: t('footer.legalPrivacy'),
-          copyright: t('footer.copyright'),
+          copyright: t('footer.copyright', { year: new Date().getFullYear().toString() }),
+          availableForProjects: t('footer.availableForProjects'),
         }}
         socialLinks={{
           linkedin: seoConfig.social.linkedin,
           github: seoConfig.social.github,
-          instagram: 'https://instagram.com/patrickbartosik',
+          instagram: seoConfig.social.instagram,
           email: seoConfig.author.email,
         }}
       />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,6 +16,7 @@ interface FooterProps {
         legalTerms: string;
         legalPrivacy: string;
         copyright: string;
+        availableForProjects: string;
     };
     socialLinks: {
         linkedin?: string;
@@ -161,7 +162,7 @@ export const Footer = ({ translations, socialLinks }: FooterProps) => {
                         </p>
                         <div className="flex items-center gap-2">
                             <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse"></div>
-                            <span className="text-white/60 text-sm">Available for projects</span>
+                            <span className="text-white/60 text-sm">{translations.availableForProjects}</span>
                         </div>
                     </div>
                 </div>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -14,6 +14,7 @@ interface HeroSectionProps {
     ctaSecondary: string;
     ctaTertiary: string;
     altText: string;
+    scrollText: string;
 }
 
 export const HeroSection = ({
@@ -23,6 +24,7 @@ export const HeroSection = ({
     ctaSecondary,
     ctaTertiary,
     altText,
+    scrollText,
 }: HeroSectionProps) => {
     const sectionRef = useRef<HTMLElement>(null);
     const titleRef = useRef<HTMLParagraphElement>(null);
@@ -278,7 +280,7 @@ export const HeroSection = ({
             >
                 <div className="flex flex-col items-center gap-3 opacity-60 hover:opacity-100 transition-opacity cursor-pointer">
                     <span className="text-white/50 text-xs tracking-widest uppercase">
-                        Scroll
+                        {scrollText}
                     </span>
                     <div className="w-6 h-10 border-2 border-white/30 rounded-full flex justify-center p-2 relative overflow-hidden">
                         <div className="w-1 h-3 bg-white/60 rounded-full animate-scroll"></div>

--- a/src/components/LatestWorkTimeline.tsx
+++ b/src/components/LatestWorkTimeline.tsx
@@ -5,8 +5,10 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { lastwork } from '@/lib/data/lastwork.data'
 import { ArrowUpRight } from 'lucide-react'
+import { useI18n } from '@/locales/client'
 
 export function LatestWorkTimeline() {
+    const t = useI18n()
     const [activeIndex, setActiveIndex] = useState(0)
     const containerRef = useRef<HTMLDivElement>(null)
     const projectRefs = useRef<HTMLDivElement[]>([])
@@ -125,11 +127,16 @@ export function LatestWorkTimeline() {
 
                         {/* Bottom Section */}
                         <div className="space-y-4">
-                            {/* Category Labels */}
+                            {/* Technology Tags */}
                             <div className="flex gap-4 text-sm text-gray-500 uppercase tracking-wider">
-                                <span>Arjuna</span>
-                                <span>Bima</span>
-                                <span className="font-bold text-white">Mandala</span>
+                                {currentProject?.technologies.slice(0, 3).map((tech, index) => (
+                                    <span
+                                        key={tech}
+                                        className={index === 0 ? "font-bold text-white" : ""}
+                                    >
+                                        {tech}
+                                    </span>
+                                ))}
                             </div>
                         </div>
                     </div>
@@ -173,7 +180,7 @@ export function LatestWorkTimeline() {
                     href="/projects"
                     className="group inline-flex items-center gap-3 px-8 py-4 bg-white text-black rounded-full text-lg font-semibold hover:bg-gray-200 transition-all duration-300 hover:scale-105"
                 >
-                    <span>More Projects</span>
+                    <span>{t('work.moreProjects')}</span>
                     <ArrowUpRight className="w-5 h-5 group-hover:translate-x-1 group-hover:-translate-y-1 transition-transform" />
                 </Link>
             </div>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -19,6 +19,7 @@ export default {
         'experience': 'years of experience',
         'projects': 'completed projects',
         'satisfaction': 'client satisfaction',
+        'scroll': 'Scroll',
     },
     'about': {
         'label': 'ABOUT',
@@ -40,6 +41,7 @@ export default {
     'work': {
         'title': 'Latest work',
         'view_all': 'View all',
+        'moreProjects': 'More Projects',
     },
     'services': {
         'title': 'My services',
@@ -157,7 +159,7 @@ export default {
         'contactCompany': 'at Patrick Bartosik®',
         'contactName': 'Patrick Bartosik',
         'contactCta': 'Ask directly',
-        'copyright': '© 2025 Patrick Bartosik® Studio',
+        'copyright': '© {year} Patrick Bartosik® Studio',
     },
     'faq': {
         'title': 'Frequently<br/>asked<br/>questions',
@@ -188,7 +190,8 @@ export default {
         'legal': 'Legal',
         'legalTerms': 'Terms of Service',
         'legalPrivacy': 'Privacy Policy',
-        'copyright': '© 2025 Patrick Bartosik. All rights reserved.',
+        'copyright': '© {year} Patrick Bartosik. All rights reserved.',
+        'availableForProjects': 'Available for projects',
     },
     'intelligentForm': {
         'step': 'Step',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -19,6 +19,7 @@ export default {
         'experience': 'ans d\'expérience',
         'projects': 'projets réalisés',
         'satisfaction': 'de satisfaction client',
+        'scroll': 'Défiler',
     },
     'about': {
         'label': 'À PROPOS',
@@ -40,6 +41,7 @@ export default {
     'work': {
         'title': 'Derniers projets',
         'view_all': 'Voir tout',
+        'moreProjects': 'Plus de projets',
     },
     'services': {
         'title': 'Mes services',
@@ -157,7 +159,7 @@ export default {
         'contactCompany': 'chez Patrick Bartosik®',
         'contactName': 'Patrick Bartosik',
         'contactCta': 'Demander directement',
-        'copyright': '© 2025 Patrick Bartosik® Studio',
+        'copyright': '© {year} Patrick Bartosik® Studio',
     },
     'faq': {
         'title': 'Questions<br/>fréquemment<br/>posées',
@@ -188,7 +190,8 @@ export default {
         'legal': 'Légal',
         'legalTerms': 'Conditions d\'utilisation',
         'legalPrivacy': 'Politique de confidentialité',
-        'copyright': '© 2025 Patrick Bartosik. Tous droits réservés.',
+        'copyright': '© {year} Patrick Bartosik. Tous droits réservés.',
+        'availableForProjects': 'Disponible pour des projets',
     },
     'intelligentForm': {
         'step': 'Étape',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -19,6 +19,7 @@ export default {
         'experience': 'lat doświadczenia',
         'projects': 'zrealizowanych projektów',
         'satisfaction': 'zadowolenia klientów',
+        'scroll': 'Przewiń',
     },
     'about': {
         'label': 'O MNIE',
@@ -40,6 +41,7 @@ export default {
     'work': {
         'title': 'Ostatnie projekty',
         'view_all': 'Zobacz wszystko',
+        'moreProjects': 'Więcej projektów',
     },
     'services': {
         'title': 'Moje usługi',
@@ -157,7 +159,7 @@ export default {
         'contactCompany': 'w Patrick Bartosik®',
         'contactName': 'Patrick Bartosik',
         'contactCta': 'Zapytaj bezpośrednio',
-        'copyright': '© 2025 Patrick Bartosik® Studio',
+        'copyright': '© {year} Patrick Bartosik® Studio',
     },
     'faq': {
         'title': 'Często<br/>zadawane<br/>pytania',
@@ -188,7 +190,8 @@ export default {
         'legal': 'Prawne',
         'legalTerms': 'Warunki świadczenia usług',
         'legalPrivacy': 'Polityka prywatności',
-        'copyright': '© 2025 Patrick Bartosik. Wszelkie prawa zastrzeżone.',
+        'copyright': '© {year} Patrick Bartosik. Wszelkie prawa zastrzeżone.',
+        'availableForProjects': 'Dostępny na projekty',
     },
     'intelligentForm': {
         'step': 'Krok',


### PR DESCRIPTION
## Summary
- **[MAJ-02/ARCH-39]** Footer "Available for projects" → i18n (FR/EN/PL)
- **[MIN-09]** HeroSection "Scroll" → i18n
- **[UX-18]** LatestWorkTimeline "More Projects" → i18n, placeholder labels replaced with real tech stack
- **[MAJ-10/UX-24]** Copyright year dynamic (`new Date().getFullYear()`) instead of hardcoded "2025"
- **[ARCH-38/MIN-08]** Instagram URLs normalized to `seoConfig.social.instagram`

## Test plan
- [ ] `bun run build` passes
- [ ] Switch locale to EN/PL and verify translated texts appear
- [ ] Copyright shows "2026" (current year)
- [ ] Instagram links all point to same URL
- [ ] LatestWorkTimeline shows project technologies instead of placeholder labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)